### PR TITLE
⬆️  go version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   codelab:
     working_directory: ~/labs
     docker:
-      - image: circleci/golang:1.11.6-node
+      - image: circleci/golang:1.16-node
     steps:
       - checkout
       - run: CGO_ENABLED=0 go get github.com/googlecodelabs/tools/claat


### PR DESCRIPTION
Mise à jour de la version de go pour que le build du codelab fonctionne.